### PR TITLE
fix: 修复订阅 User-Agent 并支持配置覆盖

### DIFF
--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -77,7 +77,7 @@ The settings json file is located at `~/homebrew/settings/DeckyClash/config.json
   "allow_remote_access": false, // Allow remote access. Default: false
   "autostart": true,            // Autostart after loaded. Default: false
   "timeout": 15.0,              // Resource query timeout (s). Default: 15.0
-  "subscription_user_agent": "", // Override subscription request User-Agent. Default: [built-in]
+  "user_agent_override": "",    // Override User-Agent. Default: [none]
   "debounce_time": 10.0,        // Query debounce time (s). Default: 10.0
   "disable_verify": false,      // Disable verify SSL. Default: false
   "external_run_bg": false,     // Run external importer in background. Default: false

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -77,6 +77,7 @@ The settings json file is located at `~/homebrew/settings/DeckyClash/config.json
   "allow_remote_access": false, // Allow remote access. Default: false
   "autostart": true,            // Autostart after loaded. Default: false
   "timeout": 15.0,              // Resource query timeout (s). Default: 15.0
+  "subscription_user_agent": "", // Override subscription request User-Agent. Default: [built-in]
   "debounce_time": 10.0,        // Query debounce time (s). Default: 10.0
   "disable_verify": false,      // Disable verify SSL. Default: false
   "external_run_bg": false,     // Run external importer in background. Default: false

--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ class Plugin:
         self._set_default("allow_remote_access", False)
         self._set_default("autostart", False)
         self._set_default("timeout", 15.0)
-        self._set_default("subscription_user_agent", "")
+        self._set_default("user_agent_override", "")
         self._set_default("debounce_time", 10.0)
         self._set_default("disable_verify", False)
         self._set_default("external_run_bg", False)
@@ -211,7 +211,6 @@ class Plugin:
             "external_run_bg",
             "auto_check_update",
             "auto_update_subscription",
-            "subscription_user_agent",
             "skip_steam_download",
         ]
         if key not in PERMITTED_KEYS:
@@ -306,7 +305,7 @@ class Plugin:
             name,
             subs[name],
             self._get("timeout"),
-            self._get("subscription_user_agent"),
+            self._get("user_agent_override"),
         )
         if result is None:
             if self.core.is_running and name == self._get("current"):
@@ -327,7 +326,7 @@ class Plugin:
                 name,
                 url,
                 self._get("timeout"),
-                self._get("subscription_user_agent"),
+                self._get("user_agent_override"),
             )
             for name, url in remote_subs
         ])
@@ -383,7 +382,7 @@ class Plugin:
             url,
             subs,
             self._get("timeout"),
-            self._get("subscription_user_agent"),
+            self._get("user_agent_override"),
         )
         if ok:
             name, url = data

--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ class Plugin:
         self._set_default("allow_remote_access", False)
         self._set_default("autostart", False)
         self._set_default("timeout", 15.0)
+        self._set_default("subscription_user_agent", "")
         self._set_default("debounce_time", 10.0)
         self._set_default("disable_verify", False)
         self._set_default("external_run_bg", False)
@@ -210,6 +211,7 @@ class Plugin:
             "external_run_bg",
             "auto_check_update",
             "auto_update_subscription",
+            "subscription_user_agent",
             "skip_steam_download",
         ]
         if key not in PERMITTED_KEYS:
@@ -300,7 +302,12 @@ class Plugin:
         if subs[name].startswith("local://"):
             logger.error(f"update_subscription: {name} is local subscription")
             return False, "local subscription"
-        result = await subscription.update_sub(name, subs[name], self._get("timeout"))
+        result = await subscription.update_sub(
+            name,
+            subs[name],
+            self._get("timeout"),
+            self._get("subscription_user_agent"),
+        )
         if result is None:
             if self.core.is_running and name == self._get("current"):
                 await self.restart_core()
@@ -316,7 +323,12 @@ class Plugin:
             return
 
         results = await asyncio.gather(*[
-            subscription.update_sub(name, url, self._get("timeout"))
+            subscription.update_sub(
+                name,
+                url,
+                self._get("timeout"),
+                self._get("subscription_user_agent"),
+            )
             for name, url in remote_subs
         ])
 
@@ -367,7 +379,12 @@ class Plugin:
 
     async def download_subscription(self, url: str) -> Tuple[bool, Optional[str]]:
         subs: subscription.SubscriptionDict = self.settings.getSetting("subscriptions")
-        ok, data = subscription.download_sub(url, subs, self._get("timeout"))
+        ok, data = subscription.download_sub(
+            url,
+            subs,
+            self._get("timeout"),
+            self._get("subscription_user_agent"),
+        )
         if ok:
             name, url = data
             subs[name] = url

--- a/py_modules/subscription.py
+++ b/py_modules/subscription.py
@@ -12,9 +12,9 @@ import core
 import decky
 from decky import logger
 import utils
+import metadata
 
 SUBSCRIPTIONS_DIR = os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "subscriptions")
-DEFAULT_USER_AGENT = lambda: f"clash-verge/v2.4.8 mihomo/{core.LAST_CORE_VERSION} clash.meta/{core.LAST_CORE_VERSION} mihomo.party/v1.9.1 DeckyClash/{decky.DECKY_PLUGIN_VERSION}"
 
 SubscriptionDict = Dict[str, str]
 Subscription = Tuple[str, str]
@@ -22,10 +22,13 @@ Subscription = Tuple[str, str]
 def get_path(filename: str) -> str:
     return os.path.join(SUBSCRIPTIONS_DIR, filename + ".yaml")
 
-def _user_agent(custom_user_agent: Optional[str] = None) -> str:
-    if custom_user_agent is not None and custom_user_agent.strip() != "":
-        return custom_user_agent.strip()
-    return DEFAULT_USER_AGENT()
+def _user_agent(user_agent_override: Optional[str] = None) -> str:
+    if user_agent_override is not None and user_agent_override.strip() != "":
+        return user_agent_override.strip()
+    return f"{metadata.PACKAGE_NAME}/{decky.DECKY_PLUGIN_VERSION} " \
+           f"mihomo/{core.LAST_CORE_VERSION} " \
+           f"clash.meta/{core.LAST_CORE_VERSION} " \
+            "clash-verge/2.4.8 mihomo.party/v1.9.4"
 
 def _deduplicate_name(now_subs: SubscriptionDict, filename: str) -> Optional[str]:
     def check_exist(name) -> bool:

--- a/py_modules/subscription.py
+++ b/py_modules/subscription.py
@@ -2,7 +2,7 @@ import asyncio
 import email
 import email.message
 import shutil
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 import os
 import urllib.request
 import urllib.parse
@@ -14,13 +14,18 @@ from decky import logger
 import utils
 
 SUBSCRIPTIONS_DIR = os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "subscriptions")
-USER_AGENT = lambda: f"{decky.DECKY_PLUGIN_NAME}/{decky.DECKY_PLUGIN_VERSION} mihomo/{core.LAST_CORE_VERSION} clash.meta/{core.LAST_CORE_VERSION} clash-verge/2.4.5 mihomo.party/v1.9.1"
+DEFAULT_USER_AGENT = lambda: f"clash-verge/v2.4.8 mihomo/{core.LAST_CORE_VERSION} clash.meta/{core.LAST_CORE_VERSION} mihomo.party/v1.9.1 DeckyClash/{decky.DECKY_PLUGIN_VERSION}"
 
 SubscriptionDict = Dict[str, str]
 Subscription = Tuple[str, str]
 
 def get_path(filename: str) -> str:
     return os.path.join(SUBSCRIPTIONS_DIR, filename + ".yaml")
+
+def _user_agent(custom_user_agent: Optional[str] = None) -> str:
+    if custom_user_agent is not None and custom_user_agent.strip() != "":
+        return custom_user_agent.strip()
+    return DEFAULT_USER_AGENT()
 
 def _deduplicate_name(now_subs: SubscriptionDict, filename: str) -> Optional[str]:
     def check_exist(name) -> bool:
@@ -41,14 +46,19 @@ def _deduplicate_name(now_subs: SubscriptionDict, filename: str) -> Optional[str
             return None
     return filename
 
-def download_sub(url: str, now_subs: SubscriptionDict, timeout: Optional[float] = None) -> Tuple[bool, Subscription | str]:
+def download_sub(
+    url: str,
+    now_subs: SubscriptionDict,
+    timeout: Optional[float] = None,
+    user_agent: Optional[str] = None,
+) -> Tuple[bool, Subscription | str]:
     """
     Download new subscription
     Args:
         url: Subscription url
         now_subs: Currently subscriptions list
         timeout: Download timeout
-        disable_verify: Disable SSL verification
+        user_agent: Override subscription request User-Agent
     Returns:
         tuple(bool, Subscription | str)
         bool: Whether download success
@@ -58,7 +68,8 @@ def download_sub(url: str, now_subs: SubscriptionDict, timeout: Optional[float] 
     if not os.path.exists(SUBSCRIPTIONS_DIR):
         os.mkdir(SUBSCRIPTIONS_DIR)
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT()})
+        ua = _user_agent(user_agent)
+        req = urllib.request.Request(url, headers={"User-Agent": ua})
         resp: http.client.HTTPResponse = urllib.request.urlopen(
             req, timeout=timeout, context=utils.get_ssl_context())
     except Exception as e:
@@ -169,9 +180,10 @@ def import_sub(file_name: str, data: bytes, now_subs: SubscriptionDict) -> Tuple
 
     return True, (filename, f"local://{filename}")
 
-async def update_sub(name: str, url: str, timeout: float) -> Optional[str]:
+async def update_sub(name: str, url: str, timeout: float, user_agent: Optional[str] = None) -> Optional[str]:
     try:
-        req = urllib.request.Request(url, headers={'User-Agent': USER_AGENT()})
+        ua = _user_agent(user_agent)
+        req = urllib.request.Request(url, headers={'User-Agent': ua})
         await utils.get_url_to_file(req, get_path(name), timeout)
     except Exception as e:
         logger.error(f"update_sub: update {name} with error {e}")


### PR DESCRIPTION
## 背景

部分订阅服务会根据请求头中的 `User-Agent` 判断客户端能力，并返回不同的订阅内容。在排查兼容性问题时发现，当前内置订阅 `User-Agent` 在某些服务商上可能拿不到完整节点列表，例如 Hysteria2 节点会被服务端过滤掉。

直接在 UI 中暴露该配置没有必要，因此本 PR 改为优先修复内置订阅 `User-Agent`，并仅在配置文件中保留可选 override。

## 修改内容

- 修复内置订阅 `User-Agent`：
  - 将已验证兼容的 `clash-verge/v2.4.8` 放在 UA 开头。
  - 保留 `mihomo`、`clash.meta`、`mihomo.party` 等既有兼容信息。
  - 使用无空格的 `DeckyClash/<version>` 作为插件标识，避免服务端解析 `Decky Clash/<version>` 这类带空格产品名时出现兼容问题。
- 新增 `subscription_user_agent` 配置项作为 override。
- 新增订阅、单个订阅更新、全部订阅更新 / 自动更新都会使用该 override。
- 当 `subscription_user_agent` 为空时，使用修复后的内置 `User-Agent`。
- 移除 UI 输入框，不在界面中暴露该配置。
- 更新 `docs/DEV_GUIDE.md`，说明 `subscription_user_agent` 配置项。

## 兼容性

默认情况下用户无需配置，DeckyClash 会使用修复后的内置 `User-Agent` 请求订阅。

如遇到特殊服务商仍需要指定请求头，可手动在 `~/homebrew/settings/DeckyClash/config.json` 中设置：

```json
"subscription_user_agent": "custom-user-agent"
```

留空字符串则回退到内置 `User-Agent`。

## 测试

- `python -m py_compile py_modules/subscription.py main.py`
- `pnpm run build`
- 手动验证：某订阅服务在旧内置 `User-Agent` 下不会返回 Hysteria2 节点；使用兼容 `User-Agent` 后可以正常获取 Hysteria2 节点。